### PR TITLE
Scram update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_derive = "1"
 r2d2 = "0.8"
 byteorder = "1"
 bufstream = "0.1"
-scram = { git = "https://github.com/tomprogrammer/scram.git", branch = "master" }
+scram = "0.5.0"
 futures = "0.1"
 parking_lot = "0.6"
 indexmap = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_derive = "1"
 r2d2 = "0.8"
 byteorder = "1"
 bufstream = "0.1"
-scram = "0.4"
+scram = { git = "https://github.com/opax7/scram.git", branch = "master" }
 futures = "0.1"
 parking_lot = "0.6"
 indexmap = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_derive = "1"
 r2d2 = "0.8"
 byteorder = "1"
 bufstream = "0.1"
-scram = { git = "https://github.com/opax7/scram.git", branch = "master" }
+scram = { git = "https://github.com/tomprogrammer/scram.git", branch = "master" }
 futures = "0.1"
 parking_lot = "0.6"
 indexmap = "1"

--- a/build/commands.rs
+++ b/build/commands.rs
@@ -1,7 +1,7 @@
+use crate::config;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use crate::config;
 
 include!(concat!(env!("CARGO_MANIFEST_DIR"), "/build/parsers.rs"));
 
@@ -33,7 +33,8 @@ impl Commands {
     pub fn generate<P: AsRef<Path>>(&self, path: P) {
         let commands: String = self.commands.join("\n");
 
-        let src = format!(r#"
+        let src = format!(
+            r#"
             impl Client {{
 
                 /// Create a new ReQL client
@@ -95,7 +96,9 @@ impl Commands {
 
                 {}
             }}
-        "#, commands);
+        "#,
+            commands
+        );
 
         let mut file = File::create(path).unwrap();
         file.write_all(src.as_bytes()).unwrap();
@@ -141,41 +144,49 @@ impl Command {
 
         let (no_args, docs) = self.gen_docs(docs);
         self.tokens = if name == "connect" {
-            format!(r#"
+            format!(
+                r#"
                 {}
                 pub fn connect<'a>(&self, cfg: Config<'a>) -> Result<Connection> {{
                     io::connect(self, cfg)
                 }}
             "#,
-                    docs)
+                docs
+            )
         } else if name == "expr" {
-            format!(r#"
+            format!(
+                r#"
                 {}
                 pub fn expr<T: IntoArg>(&self, args: T) -> Client {{
                     util::make_cmd(self, "expr", None, Some(args))
                 }}
             "#,
-                    docs)
+                docs
+            )
         } else if no_args {
-            format!(r#"
+            format!(
+                r#"
                 {docs}
                 pub fn {name}(&self) -> Client {{
                     util::make_cmd::<Client>(self, "{name}", Some({typ}), None)
                 }}
             "#,
-                    docs = docs,
-                    name = name,
-                    typ = typ)
+                docs = docs,
+                name = name,
+                typ = typ
+            )
         } else {
-            format!(r#"
+            format!(
+                r#"
                 {docs}
                 pub fn {name}<T: IntoArg>(&self, args: T) -> Client {{
                     util::make_cmd(self, "{name}", Some({typ}), Some(args))
                 }}
             "#,
-                    docs = docs,
-                    name = name,
-                    typ = typ)
+                docs = docs,
+                name = name,
+                typ = typ
+            )
         };
     }
 
@@ -190,7 +201,8 @@ impl Command {
         // The sentence following the title
         let mut next_line = String::new();
 
-        docs = docs.lines()
+        docs = docs
+            .lines()
             // If the command is documented with no args
             // we won't give it args
             .map(|line| {
@@ -223,7 +235,7 @@ impl Command {
                     if let Some(i) = line.find('.') {
                         let (t, n) = line.split_at(i);
                         doc_str.push_str(&format!("/// {}\n", t));
-                        next_line = n.trim_left_matches('.').trim().to_owned();
+                        next_line = n.trim_start_matches('.').trim().to_owned();
                         parse = true;
                         return false;
                     } else {
@@ -237,7 +249,7 @@ impl Command {
                 // Indent commands so they come out nice
                 format!("/// {}\n", line)
             })
-        .collect();
+            .collect();
 
         if !img.is_empty() {
             doc_str.push_str(&format!("///\n/// {}\n", img));
@@ -256,9 +268,13 @@ impl Command {
     }
 
     fn fixup(&self, commands: &str) -> String {
-        commands.lines()
+        commands
+            .lines()
             .map(|line| {
-                line.replace("/assets/images/docs/", "https://raw.githubusercontent.com/rethinkdb/docs/master/_jekyll/_images/")
+                line.replace(
+                    "/assets/images/docs/",
+                    "https://raw.githubusercontent.com/rethinkdb/docs/master/_jekyll/_images/",
+                )
             })
             .collect()
     }

--- a/build/config.rs
+++ b/build/config.rs
@@ -44,7 +44,8 @@ impl Config {
         let cmds_src = format!("{}/commands.rs", out_dir);
         let version = env::var("CARGO_PKG_VERSION").unwrap();
 
-        let menu = build_menu(&menu_file).into_iter()
+        let menu = build_menu(&menu_file)
+            .into_iter()
             // We are only interested in actual commands
             // that are contained in the sections
             .map(|menu| menu.section)
@@ -63,9 +64,7 @@ impl Config {
             })
             // Match filesystem formating of section directories
             .map(|mut section| {
-                section.name = section.name
-                    .replace(" ", "-")
-                    .to_lowercase();
+                section.name = section.name.replace(" ", "-").to_lowercase();
                 section
             });
 
@@ -76,7 +75,8 @@ impl Config {
                 commands.push(command);
             }
         }
-        commands = commands.into_iter()
+        commands = commands
+            .into_iter()
             // Drop blacklisted sections
             .filter(|command| {
                 let blacklist = vec!["cursors"];
@@ -87,60 +87,71 @@ impl Config {
                 }
                 true
             })
-        // Drop blacklisted commands
-        .filter(|command| {
-            let blacklist = vec![
-                "r", "args", "use", "row", "opt_arg", "array", "object", "close", "reconnect",
-                "noreply_wait", "server", "event_emitter", "run",
-            ];
-            for cmd in blacklist {
-                if cmd == command.permalink {
-                    return false;
+            // Drop blacklisted commands
+            .filter(|command| {
+                let blacklist = vec![
+                    "r",
+                    "args",
+                    "use",
+                    "row",
+                    "opt_arg",
+                    "array",
+                    "object",
+                    "close",
+                    "reconnect",
+                    "noreply_wait",
+                    "server",
+                    "event_emitter",
+                    "run",
+                ];
+                for cmd in blacklist {
+                    if cmd == command.permalink {
+                        return false;
+                    }
                 }
-            }
-            true
-        })
-        // Rename special keywords
-        .map(|mut command| {
-            let keywords = vec!["mod", "match", "do"];
-            for cmd in keywords {
-                if cmd == command.permalink {
-                    command.method = Some(format!("{}_", command.permalink));
+                true
+            })
+            // Rename special keywords
+            .map(|mut command| {
+                let keywords = vec!["mod", "match", "do"];
+                for cmd in keywords {
+                    if cmd == command.permalink {
+                        command.method = Some(format!("{}_", command.permalink));
+                    }
                 }
-            }
-            command
-        })
-        // Rename commands
-        .map(|mut command| {
-            let names = vec![("to_json_string", "to_json")];
-            for (old, new) in names {
-                if old == command.permalink {
-                    command.method = Some(new.into());
+                command
+            })
+            // Rename commands
+            .map(|mut command| {
+                let names = vec![("to_json_string", "to_json")];
+                for (old, new) in names {
+                    if old == command.permalink {
+                        command.method = Some(new.into());
+                    }
                 }
-            }
-            command
-        })
-        // Commands with different types
-        .map(|mut command| {
-            let types = vec![("js", "javascript"), ("do", "funcall")];
-            for (cmd, typ) in types {
-                if cmd == command.permalink {
-                    command.typ = Some(typ.into());
+                command
+            })
+            // Commands with different types
+            .map(|mut command| {
+                let types = vec![("js", "javascript"), ("do", "funcall")];
+                for (cmd, typ) in types {
+                    if cmd == command.permalink {
+                        command.typ = Some(typ.into());
+                    }
                 }
-            }
-            command
-        })
-        // Commands in different sections
-        .map(|mut command| {
-            let menu = vec![("changes", "manipulating-tables")];
-            for (cmd, section) in menu {
-                if cmd == command.permalink {
-                    command.section = section.to_owned();
+                command
+            })
+            // Commands in different sections
+            .map(|mut command| {
+                let menu = vec![("changes", "manipulating-tables")];
+                for (cmd, section) in menu {
+                    if cmd == command.permalink {
+                        command.section = section.to_owned();
+                    }
                 }
-            }
-            command
-        })
-        .collect();
+                command
+            })
+            .collect();
 
         Config {
             docs_dir: PathBuf::from(&docs_dir),

--- a/build/main.rs
+++ b/build/main.rs
@@ -3,8 +3,8 @@ extern crate nom;
 #[macro_use]
 extern crate serde_derive;
 
-mod config;
 mod commands;
+mod config;
 
 use self::commands::{Command, Commands};
 use self::config::Config;

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -1,10 +1,10 @@
+extern crate futures;
 extern crate reql;
 extern crate reql_types;
-extern crate futures;
 
 use futures::Stream;
+use reql::{Client, Config, Document, Run};
 use reql_types::ServerStatus;
-use reql::{Config, Client, Document, Run};
 
 fn main() -> reql::Result<()> {
     // Create a new ReQL client
@@ -14,7 +14,8 @@ fn main() -> reql::Result<()> {
     let conn = r.connect(Config::default())?;
 
     // Run the query
-    let stati = r.db("rethinkdb")
+    let stati = r
+        .db("rethinkdb")
         .table("server_status")
         .run::<ServerStatus>(conn)?;
 

--- a/examples/changes.rs
+++ b/examples/changes.rs
@@ -1,13 +1,13 @@
+extern crate futures;
 extern crate reql;
 extern crate reql_types;
-extern crate futures;
 
 #[macro_use]
 extern crate serde_derive;
 
-use reql::{Config, Client, Run};
-use reql_types::Change;
 use futures::Stream;
+use reql::{Client, Config, Run};
+use reql_types::Change;
 use std::net::IpAddr;
 use std::net::SocketAddr;
 
@@ -19,7 +19,6 @@ struct TestChange {
     id: String,
     data: String,
 }
-
 
 // This example requires a rethinkdb with a db called "test" with a table called "testdata"
 // It will printout the entire "Change" struct when a new entry is inserted/changed/deleted in
@@ -35,7 +34,7 @@ fn main() -> reql::Result<()> {
     let addr = "127.0.0.1".parse::<IpAddr>().unwrap();
     let socket = SocketAddr::new(addr, 28015);
     conf.db = "test";
-    conf.servers = vec!(socket);
+    conf.servers = vec![socket];
     conf.user = "admin";
     conf.password = "";
 
@@ -43,7 +42,8 @@ fn main() -> reql::Result<()> {
     let conn = r.connect(conf).unwrap();
 
     // Run the query on "testdata" table
-    let query = r.db("test")
+    let query = r
+        .db("test")
         .table("testdata")
         .changes()
         .run::<Change<TestChange, TestChange>>(conn)?;
@@ -52,20 +52,18 @@ fn main() -> reql::Result<()> {
 
     // Process each new response from the database
     loop {
-       let change = changes.next();
-       match change {
-
+        let change = changes.next();
+        match change {
             // The server responded with something
             Some(Ok(Some(data))) => {
                 println!("{:?}", data);
-            },
+            }
             Some(Err(e)) => {
                 println!("Error {}", e);
-            },
+            }
             _ => {
                 println!("Something else happened");
-            },
-       };
-
+            }
+        };
     }
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,10 +1,10 @@
+extern crate futures;
 extern crate reql;
 extern crate reql_types;
-extern crate futures;
 
-use reql::{Config, Client, Document, Run};
-use reql_types::ServerStatus;
 use futures::Stream;
+use reql::{Client, Config, Document, Run};
+use reql_types::ServerStatus;
 
 fn main() -> reql::Result<()> {
     // Create a new ReQL client
@@ -14,42 +14,44 @@ fn main() -> reql::Result<()> {
     let conn = r.connect(Config::default()).unwrap();
 
     // Run the query
-    let query = r.db("rethinkdb")
+    let query = r
+        .db("rethinkdb")
         .table("server_status")
         .run::<ServerStatus>(conn)?;
 
     // Process the results
-    let stati = query.and_then(|status| {
-        match status {
-            // The server returned the response we were expecting
-            Some(Document::Expected(status)) => {
-                println!("{:?}", status);
+    let stati = query
+        .and_then(|status| {
+            match status {
+                // The server returned the response we were expecting
+                Some(Document::Expected(status)) => {
+                    println!("{:?}", status);
+                }
+                // We got a response alright, but it wasn't the one we were
+                // expecting plus it's not an error either, otherwise it would
+                // have been returned as such (This simply means that the response
+                // we got couldn't be serialised into the type we were expecting)
+                Some(Document::Unexpected(status)) => {
+                    println!("unexpected response from server: {:?}", status);
+                }
+                // This is impossible in this particular example since there
+                // needs to be at least one server available to give this
+                // response otherwise we would have run into an error for
+                // failing to connect
+                None => {
+                    println!("got no documents in the database");
+                }
             }
-            // We got a response alright, but it wasn't the one we were
-            // expecting plus it's not an error either, otherwise it would
-            // have been returned as such (This simply means that the response
-            // we got couldn't be serialised into the type we were expecting)
-            Some(Document::Unexpected(status)) => {
-                println!("unexpected response from server: {:?}", status);
-            }
-            // This is impossible in this particular example since there
-            // needs to be at least one server available to give this
-            // response otherwise we would have run into an error for
-            // failing to connect
-            None => {
-                println!("got no documents in the database");
-            }
-        }
-        Ok(())
-    })
-    // Our query ran into an error
-    .or_else(|error| {
-        println!("{:?}", error);
-        Err(())
-    });
+            Ok(())
+        })
+        // Our query ran into an error
+        .or_else(|error| {
+            println!("{:?}", error);
+            Err(())
+        });
 
     // Wait for all the results to be processed
-    for _ in stati.wait() { }
+    for _ in stati.wait() {}
 
     Ok(())
 }

--- a/src/commands/args.rs
+++ b/src/commands/args.rs
@@ -1,7 +1,4 @@
-use crate::{
-    Arg, Client, Connection, IntoArg, Result,
-    types::FromJson,
-};
+use crate::{types::FromJson, Arg, Client, Connection, IntoArg, Result};
 use ql2::proto::{Term, Term_AssocPair as TermPair};
 use serde_json::value::Value;
 
@@ -157,7 +154,6 @@ impl IntoArg for Value {
     }
 }
 
-
 impl IntoArg for Connection {
     fn into_arg(self) -> Arg {
         Arg {
@@ -167,7 +163,6 @@ impl IntoArg for Connection {
         }
     }
 }
-
 
 impl Arg {
     /// Create a new command argument

--- a/src/commands/io/handshake.rs
+++ b/src/commands/io/handshake.rs
@@ -52,7 +52,7 @@ impl Session {
         parse_server_version(&self.stream)?;
 
         // Send client first message
-        let scram = ScramClient::new(&opts.user, &opts.password, None)?;
+        let scram = ScramClient::new(&opts.user, &opts.password, None);
         let (scram, client_first) = scram.client_first();
 
         let ar = AuthRequest {

--- a/src/commands/io/pool.rs
+++ b/src/commands/io/pool.rs
@@ -1,8 +1,5 @@
 use super::io_error;
-use crate::{
-    Connection, Result, Session, SessionManager,
-    errors::Error,
-};
+use crate::{errors::Error, Connection, Result, Session, SessionManager};
 use r2d2;
 use std::net::TcpStream;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,8 +1,8 @@
+mod args;
 mod io;
 mod util;
-mod args;
 
-use crate::{Config, Client, IntoArg, Result, Connection};
+use crate::{Client, Config, Connection, IntoArg, Result};
 use ql2::proto::{Term, Term_TermType as Type};
 
 include!(concat!(env!("OUT_DIR"), "/commands.rs"));

--- a/src/commands/util.rs
+++ b/src/commands/util.rs
@@ -11,11 +11,12 @@ pub fn new_client() -> Client {
     }
 }
 
-pub fn make_cmd<A: IntoArg>(client: &Client,
-                            name: &'static str,
-                            cmd_type: Option<Term_TermType>,
-                            args: Option<A>)
-                            -> Client {
+pub fn make_cmd<A: IntoArg>(
+    client: &Client,
+    name: &'static str,
+    cmd_type: Option<Term_TermType>,
+    args: Option<A>,
+) -> Client {
     let cterm = match client.term {
         Ok(ref term) => term.clone(),
         Err(_) => {
@@ -56,9 +57,11 @@ pub fn make_cmd<A: IntoArg>(client: &Client,
 
 fn push_args(cmd: &mut Client, mut tmp_args: Term) {
     if let Ok(ref mut term) = cmd.term {
-        if tmp_args.has_field_type() { // did not come from the args macro
+        if tmp_args.has_field_type() {
+            // did not come from the args macro
             term.mut_args().push(tmp_args);
-        } else { // came from the args macro
+        } else {
+            // came from the args macro
             for arg in tmp_args.take_args().into_vec() {
                 term.mut_args().push(arg);
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,12 +4,12 @@ use std::io::Error as IoError;
 use std::str::Utf8Error;
 use std::sync::Arc;
 
-use protobuf::ProtobufError;
-use {scram, r2d2};
-use serde_json::Value;
-use futures::sync::mpsc::SendError;
-use serde_json::error::Error as JsonError;
 use derive_error as de;
+use futures::sync::mpsc::SendError;
+use protobuf::ProtobufError;
+use serde_json::error::Error as JsonError;
+use serde_json::Value;
+use {r2d2, scram};
 
 /// The most generic error message in ReQL
 #[derive(Debug, Clone, de::Error)]
@@ -135,20 +135,17 @@ impl From<ProtobufError> for Error {
     }
 }
 
-
 impl From<r2d2::Error> for Error {
     fn from(err: r2d2::Error) -> Error {
         From::from(DriverError::R2D2(err))
     }
 }
 
-
 impl From<scram::Error> for Error {
     fn from(err: scram::Error) -> Error {
         From::from(DriverError::Scram(err))
     }
 }
-
 
 impl<T> From<SendError<T>> for Error {
     fn from(err: SendError<T>) -> Error {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,31 +6,31 @@ use std::process::Command;
 pub fn setup() {
     //setup code specific to your library's tests would go here
     Command::new("sh")
-	.arg("-c")
-	.arg("rm -rf tests/rethinkdb_data")
-	.spawn()
-	.expect("failed to kill databases");
+        .arg("-c")
+        .arg("rm -rf tests/rethinkdb_data")
+        .spawn()
+        .expect("failed to kill databases");
 
     Command::new("sh")
-	.arg("-c")
-	.arg("cp -r tests/fresh_data tests/rethinkdb_data")
-	.spawn()
-	.expect("failed to kill databases");
+        .arg("-c")
+        .arg("cp -r tests/fresh_data tests/rethinkdb_data")
+        .spawn()
+        .expect("failed to kill databases");
 
     Command::new("sh")
-	.arg("-c")
-	.arg("killall rethinkdb")
-	.spawn()
-	.expect("failed to kill databases");
+        .arg("-c")
+        .arg("killall rethinkdb")
+        .spawn()
+        .expect("failed to kill databases");
 
     std::thread::sleep(std::time::Duration::from_millis(500));
 
     Command::new("rethinkdb")
-	.arg("--daemon")
-	.arg("--directory")
-	.arg("tests/rethinkdb_data")
-	.spawn()
-	.expect("failed to start database");
-	// takes time for the test to get tables ready
-	std::thread::sleep(std::time::Duration::from_secs(20));
+        .arg("--daemon")
+        .arg("--directory")
+        .arg("tests/rethinkdb_data")
+        .spawn()
+        .expect("failed to start database");
+    // takes time for the test to get tables ready
+    std::thread::sleep(std::time::Duration::from_secs(20));
 }

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -6,7 +6,6 @@ mod common;
 
 #[test]
 fn it_connects() {
-
     common::setup();
     let conf = Config::default();
 
@@ -17,7 +16,7 @@ fn it_connects() {
     let conn = r.connect(conf);
     std::thread::sleep(std::time::Duration::from_millis(1000));
     assert!(conn.is_ok());
-//    assert_eq!(4, adder::add_two(2));
+    //    assert_eq!(4, adder::add_two(2));
 }
 
 // ignored commented due to crashing the test-suite
@@ -29,7 +28,7 @@ fn it_fails_to_connect() {
     // should no be any connection available here
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1234);
 
-    conf.servers = vec!(socket);
+    conf.servers = vec![socket];
 
     let r = Client::new();
     // Create a connection pool

--- a/tests/data_handling.rs
+++ b/tests/data_handling.rs
@@ -1,15 +1,15 @@
+extern crate futures;
 extern crate reql;
 extern crate reql_types;
-extern crate futures;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 
+use futures::Stream;
+use reql::Document::*;
 use reql::*;
 use reql_types::*;
-use reql::Document::*;
-use futures::Stream;
 
 mod common;
 
@@ -40,7 +40,8 @@ fn can_write() {
         count: 0,
     };
 
-    let stat = r.db("test")
+    let stat = r
+        .db("test")
         .table("tests")
         .insert(json!(scrap))
         .run::<WriteStatus>(conn);
@@ -54,7 +55,6 @@ fn can_write() {
     } else {
         assert!(false);
     }
-
 }
 
 /// Reads the server status fields and verifies that the correct port has been inserted in the field
@@ -70,7 +70,8 @@ fn can_read() {
 
     let conn = r.connect(conf).unwrap();
 
-    let stat = r.db("rethinkdb")
+    let stat = r
+        .db("rethinkdb")
         .table("server_status")
         .run::<ServerStatus>(conn);
 
@@ -83,5 +84,4 @@ fn can_read() {
     } else {
         assert!(false);
     }
-
 }

--- a/tests/zchangefeed.rs
+++ b/tests/zchangefeed.rs
@@ -1,17 +1,17 @@
+extern crate futures;
 extern crate reql;
 extern crate reql_types;
-extern crate futures;
 #[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
 
+use futures::Stream;
 use reql::*;
 use reql_types::*;
-use futures::Stream;
 
-use std::sync::*;
 use std::io::*;
+use std::sync::*;
 
 mod common;
 
@@ -42,7 +42,8 @@ fn writer() -> u32 {
     loop {
         //println!("sending {}", amount);
         scrap.count += 1;
-        let stat = r.db("test")
+        let stat = r
+            .db("test")
             .table("tests")
             .get("hej")
             .replace(json!(scrap))
@@ -58,13 +59,10 @@ fn writer() -> u32 {
     amount
 }
 
-
-
 #[test]
 /// Starts a thread that will write, a thread that reads the changes and then compares the amount
 fn changefeeds_for_a_long_time() {
     common::setup();
-
 
     let counter = Arc::new(Mutex::new(0));
 
@@ -78,18 +76,19 @@ fn changefeeds_for_a_long_time() {
         println!("");
         println!("Reader Connected");
 
-        let stat = r.db("test")
+        let stat = r
+            .db("test")
             .table("tests")
             .changes()
-            .run::<Change<Scrap,Scrap>>(conn);
+            .run::<Change<Scrap, Scrap>>(conn);
 
         let mut wait = stat.unwrap().wait();
         loop {
-            let _data  = wait.next().unwrap();
+            let _data = wait.next().unwrap();
 
             let mut amount = read_counter.lock().unwrap();
             *amount += 1;
-            print!("Receiving {:6}/{} ... \r", *amount, CHANGES );
+            print!("Receiving {:6}/{} ... \r", *amount, CHANGES);
             let _ = stdout().flush();
         }
     });
@@ -106,6 +105,9 @@ fn changefeeds_for_a_long_time() {
 
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    assert_eq!(written, *counter.lock().unwrap(), "wrote and read diff amount");
-
+    assert_eq!(
+        written,
+        *counter.lock().unwrap(),
+        "wrote and read diff amount"
+    );
 }


### PR DESCRIPTION
Scram will include an update to its "ring" dependency which is a breaking change to the API. This PR is to update to the "scram 0.5.0" release, formatting, and deprecation warning changes.

This is relevant to me because in my current project, I am using both the "jsonwebtoken" crate along with the "reql" crate; both of which have either a direct or upstream dependency on the "ring" crate. The "scram 0.5.0" release brings "reql" and "jsonwebtoken" into agreeable versions of "ring".

Please note that this PR is dependent on the "scram 0.5.0" release which hasn't be produced yet, although the PR has been approved and merged.