### PR TITLE
Allow creating index using binary representation

### DIFF
--- a/reql/src/cmd/index_create.rs
+++ b/reql/src/cmd/index_create.rs
@@ -47,9 +47,8 @@ where
     R: Into<Command>,
 {
     fn arg(self) -> cmd::Arg<Options> {
-        let Args((name, query)) = self;
-        let func = Func::row(query);
-        Args((name, func)).arg()
+        let Args((name, func)) = self;
+        name.arg().with_arg(func)
     }
 }
 
@@ -79,8 +78,7 @@ where
     R: Into<Command>,
 {
     fn arg(self) -> cmd::Arg<Options> {
-        let Args((name, query, opts)) = self;
-        let Func(func) = Func::row(query);
+        let Args((name, func, opts)) = self;
         name.arg().with_arg(func).with_opts(opts)
     }
 }


### PR DESCRIPTION
While building an alternative import tool for rethinkdb using Rust, I
found myself trying to create index using the binary representation, as
exported by the official export tool.

However, the current implementation always wrap everything in a `Func`
so that didn't work, this PR is an attempt to fix that.

There's probably a better way to do this, but I'm not sure how.
